### PR TITLE
Add missing cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "casmo-simulate-syntax",
-  "version": "0.0.1",
+  "name": "casmo-casmo-simulate-syntax",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "casmo-simulate-syntax",
-      "version": "0.0.1",
+      "name": "casmo-casmo-simulate-syntax",
+      "version": "1.0.1",
+      "license": "MIT",
       "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "casmo-casmo-simulate-syntax",
+  "name": "casmo-simulate-syntax",
   "displayName": "CASMO/SIMULATE Syntax",
   "description": "Provides syntax highlighting for SIMULATE3/5 input deck files",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "vscode": "^1.73.0"
   },

--- a/syntaxes/simulate-input.tmLanguage.json
+++ b/syntaxes/simulate-input.tmLanguage.json
@@ -24,11 +24,11 @@
 		},
 		{
 			"name": "keyword.card.double.simulate",
-			"match": "^\\s*'[A-Z]{3}\\.[A-Z]{3}'"
+			"match": "^\\s*'[A-Z]{3}\\.[A-Z0-9]{3}'"
 		},
 		{
 			"name": "keyword.card.single.simulate",
-			"match": "^\\s*'[A-Z]{3}'"
+			"match": "^\\s*'([A-Z]{3}|ECHO|NOECHO|STOP)'"
 		},
 		{
 			"name": "keyword.seperator.comma.simulate",

--- a/syntaxes/simulate-output.tmLanguage.json
+++ b/syntaxes/simulate-output.tmLanguage.json
@@ -24,11 +24,11 @@
 		},
 		{
 			"name": "keyword.card.double.simulate",
-			"match": "^\\s*'[A-Z]{3}\\.[A-Z]{3}'"
+			"match": "^\\s*'[A-Z]{3}\\.[A-Z0-9]{3}'"
 		},
 		{
 			"name": "keyword.card.single.simulate",
-			"match": "^\\s*'[A-Z]{3}'"
+			"match": "^\\s*'([A-Z]{3}|ECHO|NOECHO|STOP)'"
 		},
 		{
 			"name": "keyword.seperator.comma.simulate",


### PR DESCRIPTION
@trb5016 nice work on the extension!

This PR updates to the regex to catch some additional cards. e.g.
`'ECHO'`
`'NOECHO'`
`'STOP'`
`'CRD.B10'` 
etc.

I was not sure about the package name. Looks like it changed from when the version was `0.0.1` and `1.0.0`.